### PR TITLE
added a few opt-in rules, added a few custom rules

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,6 +1,6 @@
 ###
 # Swiftlint configuration file.
-# Latest version supported: 0.9.1
+# Latest version supported: 0.11.1
 # Any newer version hasn't been checked yet and might not follow the style guide.
 ###
 
@@ -35,6 +35,48 @@ line_length:
 type_body_length:
   - 400 #warning
   - 500 #error
+  
+opt_in_rules:
+  - empty_count
+  - missing_docs
+  - force_unwrapping
+
+custom_rules:
+  comments_space:
+    name: "Space After Comment"
+    regex: "(^ *//\w+)"
+    message: "There should be a space after //"
+    severity: error
+  comments_capitalized_ignore_possible_code:
+    name: "Capitalize First Word In Comment"
+    regex: "(^ +// +(?!swiftlint)[a-z]+)"
+    message: "The first word of a comment should be capitalized"
+    severity: error
+  empty_first_line:
+    name: "Empty First Line"
+    regex: "(^[ a-zA-Z ]*(?:protocol|extension|class|struct) (?!(?:var|let))[ a-zA-Z:]*\{\n *\S+)"
+    message: "There should be an empty line after a declaration"
+    severity: error
+  empty_line_after_guard:
+    name: "Empty Line After Guard"
+    regex: "(^ *guard[ a-zA-Z0-9=?.\(\),><!]*\{[ a-zA-Z0-9=?.\(\),><!]*\}\n *(?!(?:return|guard))\S+)"
+    message: "There should be an empty line after a guard"
+    severity: error
+  empty_line_after_super:
+    name: "Empty Line After Super"
+    regex: "(^ *super\.[ a-zA-Z0-9=?.\(\)\{\}:,><!]*\n *(?!(?:\}|return))\S+)"
+    message: "There should be an empty line after super"
+    severity: error
+  multiple_empty_lines:
+    name: "Multiple Empty Lines"
+    regex: "((?:\s*\n){3,})"
+    message: "There are too many line breaks"
+    severity: error
+  unnecessary_type:
+    name: "Unnecessary Type"
+    regex: "[ a-zA-Z0-9]*(?:let|var) [ a-zA-Z0-9]*: ([a-zA-Z0-9]*)[\? ]*= \1"
+    message: "Type Definition Not Needed"
+    severity: error
 
 ####### enabled rules #######
 #  - comma # k,v >> k, v

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -37,7 +37,6 @@ type_body_length:
   - 500 #error
   
 opt_in_rules:
-  - empty_count
   - missing_docs
   - force_unwrapping
 


### PR DESCRIPTION
opt-in rules:
  missing_docs - public function needs a doc comment
  force_unwrapping - (myOptional!)

custom rules:
  Space After Comment - //MARK -> // MARK
  comments_capitalized_ignore_possible_code - // starts timer -> // Starts timer
  empty_first_line - forces empty line after declaration after protocol, extension, class, struct declaration
  empty_line_after_guard - forces empty line after guard statement
  empty_line_after_super - forces empty line after super calls
  multiple_empty_lines - allows only 1 empty line
  unnecessary_type - var counter: Int = 1 -> var counter = 1
