### PR TITLE
Ingnore rule if multiple spaces

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -52,7 +52,7 @@ custom_rules:
     severity: warning
   comments_capitalized_ignore_possible_code:
     name: "Capitalize First Word In Comment"
-    regex: "(^ +// +(?!swiftlint)[a-z]+)"
+    regex: "(^ +// {1}(?!swiftlint)[a-z]+)"
     message: "The first word of a comment should be capitalized"
     severity: warning
   empty_first_line:


### PR DESCRIPTION
So the rule warns in this case:

```
// lower case (warning)
```

as it should be:

```
// Upper case (no warning)
```

But when there is an indentation and some code shown, then the warning does not make sense.

```
// Super explanation about something
//     if (myCodeIsCool == true) {
//          doSomething()
//     }
```

With this change this rule only apply if there is just one space after the `//`
